### PR TITLE
Add in the `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Add the dependabot to check daily the dependencies of the gradle dependabot. If it finds a new dependency version available, create a PR with the label: `dependencies`.