### PR TITLE
Add the `Build` & `Validation` GitHub workflows

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,25 @@
+name: "Build"
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    name: "Build on ${{ matrix.java }}"
+    strategy:
+      matrix:
+        java: [ 17 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Set up JDK: ${{ matrix.java }}"
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Execute Gradle build
+        run: ./gradlew build

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [ push, pull_request ]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
- Add the `Validation` action to validates the checksums of Gradle Wrapper JAR files. 
- Add the `Build` action to run the gradle command: `./gradlew build` on `JDK-17`

Note: both action will run on `push` and `pull_request`

