### PR TITLE
Fix the missing `io.ktor.client.engine.HttpClientEngine` dependency

### DIFF
--- a/clashJ/build.gradle.kts
+++ b/clashJ/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 
     implementation("io.ktor:ktor-client-core:2.3.4")
-    implementation("io.ktor:ktor-client-apache5:2.3.4")
+    api("io.ktor:ktor-client-apache5:2.3.4")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.4")
     implementation("io.ktor:ktor-serialization-gson:2.3.4")
     testImplementation("io.ktor:ktor-client-mock:2.3.4")


### PR DESCRIPTION
This PR fixes the missing `io.ktor.client.engine.HttpClientEngine` dependency. When the library was imported, the build failed to return the following error:
```
Cannot access class 'io.ktor.client.engine.HttpClientEngine'. Check your module classpath for missing or conflicting dependencies.
```

The error occurs because the `Apache5` dependency did not leak into users' compile time so the `ClientBuilder` was not able to build the `engine`.